### PR TITLE
Makes the crate work on Windows as well.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,5 +12,8 @@ version = "0.1.0"
 [badges.travis-ci]
 repository = "fitzgen/is_executable"
 
+[dependencies]
+winapi = { version = "0.3", features = ["winuser"] }
+
 [dev-dependencies]
 diff = "0.1.10"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ version = "0.1.1"
 [badges.travis-ci]
 repository = "fitzgen/is_executable"
 
-[dependencies]
+[target.'cfg(target_os = "windows")'.dependencies]
 winapi = { version = "0.3", features = ["winbase"] }
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ version = "0.1.0"
 repository = "fitzgen/is_executable"
 
 [dependencies]
-winapi = { version = "0.3", features = ["winuser"] }
+winapi = { version = "0.3", features = ["winbase"] }
 
 [dev-dependencies]
 diff = "0.1.10"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0/MIT"
 name = "is_executable"
 readme = "./README.md"
 repository = "https://github.com/fitzgen/is_executable"
-version = "0.1.0"
+version = "0.1.1"
 [badges.travis-ci]
 repository = "fitzgen/is_executable"
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ The API comes in two flavors:
     fn main() {
         let path = Path::new("some/path/to/a/file");
 
+        // Determine if `path` is executable.
         if is_executable(&path) {
             println!("The path is executable!");
         } else {

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/fitzgen/is_executable.svg?branch=master)](https://travis-ci.org/fitzgen/is_executable)
+
 # is_executable
 
 Is there an executable file at the given path?
@@ -7,57 +9,48 @@ Is there an executable file at the given path?
 A small helper function which determines whether or not the given path points to
 an executable file. If there is no file at the given path, or the file is not
 executable, then `false` is returned. When there is a file and the file is
-executable, then `true` is returend.
+executable, then `true` is returned.
 
-Answering this question is OS specific: some operating systems (Windows) do not
-distinguish between executable and non-executable file permissions. On such
-OSes, if there is a file at the given path, then `true` is returned.
+This crate works on both unix-based operating systems (mac, linux, freebsd, etc.) and Windows.
 
 The API comes in two flavors:
 
-1. An extension trait to add an `is_executable` method on `std::path::Path` and
-   `std::fs::Permissions`:
+1. An extension trait to add an `is_executable` method on `std::path::Path`:
 
-   ```rust
-   use is_executable::IsExecutable;
-   use std::fs;
-   use std::path::Path;
+    ```rust
+    use std::path::Path;
 
-   let path = Path::new("some/path/to/a/file");
+    use is_executable::IsExecutable;
 
-   // Determine if `path` is executable.
-   if path.is_executable() {
-       println!("The path is executable!");
-   } else {
-       println!("The path is _not_ executable!");
-   }
+    fn main() {
+        let path = Path::new("some/path/to/a/file");
 
-   // Determine if some `std::fs::Metadata`'s `std::fs::Permissions` are
-   // executable.
-   # let _foo = || -> ::std::io::Result<()> {
-   if fs::metadata("some/path")?.permissions().is_executable() {
-       println!("The permissions are executable!");
-   } else {
-       println!("The permissions are _not_ executable!");
-   }
-   # Ok(())
-   # };
-   ```
+        // Determine if `path` is executable.
+        if path.is_executable() {
+            println!("The path is executable!");
+        } else {
+            println!("The path is _not_ executable!");
+        }
+    }
+    ```
 
 2. For convenience, a standalone `is_executable` function, which takes any
 `AsRef<Path>`:
 
-   ```rust
-   use is_executable::is_executable;
-   use std::path::Path;
+    ```rust
+    use std::path::Path;
 
-   let path = Path::new("some/path/to/a/file");
+    use is_executable::is_executable;
 
-   if is_executable(&path) {
-       println!("The path is executable!");
-   } else {
-       println!("The path is _not_ executable!");
-   }
-   ```
+    fn main() {
+        let path = Path::new("some/path/to/a/file");
+
+        if is_executable(&path) {
+            println!("The path is executable!");
+        } else {
+            println!("The path is _not_ executable!");
+        }
+    }
+    ```
 
 License: Apache-2.0/MIT

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,68 +6,62 @@ Is there an executable file at the given path?
 A small helper function which determines whether or not the given path points to
 an executable file. If there is no file at the given path, or the file is not
 executable, then `false` is returned. When there is a file and the file is
-executable, then `true` is returend.
+executable, then `true` is returned.
 
-Answering this question is OS specific: some operating systems (Windows) do not
-distinguish between executable and non-executable file permissions. On such
-OSes, if there is a file at the given path, then `true` is returned.
+This crate works on both unix-based operating systems (mac, linux, freebsd, etc.) and Windows.
 
 The API comes in two flavors:
 
-1. An extension trait to add an `is_executable` method on `std::path::Path` and
-   `std::fs::Permissions`:
+1. An extension trait to add an `is_executable` method on `std::path::Path`:
 
-   ```rust
-   use is_executable::IsExecutable;
-   use std::fs;
-   use std::path::Path;
+    ```rust
+    use std::path::Path;
 
-   let path = Path::new("some/path/to/a/file");
+    use is_executable::IsExecutable;
 
-   // Determine if `path` is executable.
-   if path.is_executable() {
-       println!("The path is executable!");
-   } else {
-       println!("The path is _not_ executable!");
-   }
+    fn main() {
+        let path = Path::new("some/path/to/a/file");
 
-   // Determine if some `std::fs::Metadata`'s `std::fs::Permissions` are
-   // executable.
-   # let _foo = || -> ::std::io::Result<()> {
-   if fs::metadata("some/path")?.permissions().is_executable() {
-       println!("The permissions are executable!");
-   } else {
-       println!("The permissions are _not_ executable!");
-   }
-   # Ok(())
-   # };
-   ```
+        // Determine if `path` is executable.
+        if path.is_executable() {
+            println!("The path is executable!");
+        } else {
+            println!("The path is _not_ executable!");
+        }
+    }
+    ```
 
 2. For convenience, a standalone `is_executable` function, which takes any
 `AsRef<Path>`:
 
-   ```rust
-   use is_executable::is_executable;
-   use std::path::Path;
+    ```rust
+    use std::path::Path;
 
-   let path = Path::new("some/path/to/a/file");
+    use is_executable::is_executable;
 
-   if is_executable(&path) {
-       println!("The path is executable!");
-   } else {
-       println!("The path is _not_ executable!");
-   }
-   ```
+    fn main() {
+        let path = Path::new("some/path/to/a/file");
+
+        // Determine if `path` is executable.
+        if is_executable(&path) {
+            println!("The path is executable!");
+        } else {
+            println!("The path is _not_ executable!");
+        }
+    }
+    ```
  */
 
-use std::fs;
 use std::path::Path;
 
 /// Returns `true` if there is a file at the given path and it is
 /// executable. Returns `false` otherwise.
 ///
 /// See the module documentation for details.
-pub fn is_executable<P: AsRef<Path>>(path: P) -> bool {
+pub fn is_executable<P>(path: P) -> bool
+where
+    P: AsRef<Path>,
+{
     path.as_ref().is_executable()
 }
 
@@ -82,23 +76,62 @@ pub trait IsExecutable {
     fn is_executable(&self) -> bool;
 }
 
-impl IsExecutable for Path {
-    fn is_executable(&self) -> bool {
-        fs::metadata(self)
-            .ok()
-            .map_or(false, |meta| meta.permissions().is_executable())
+#[cfg(unix)]
+mod unix {
+    use std::os::unix::fs::PermissionsExt;
+    use std::path::Path;
+
+    use super::IsExecutable;
+
+    impl IsExecutable for Path {
+        fn is_executable(&self) -> bool {
+            let metadata = match self.metadata() {
+                Ok(metadata) => metadata,
+                Err(_) => return false,
+            };
+            let permissions = metadata.permissions();
+            permissions.mode() & 0o111 != 0
+        }
     }
 }
 
-impl IsExecutable for fs::Permissions {
-    #[cfg(unix)]
-    fn is_executable(&self) -> bool {
-        use std::os::unix::fs::PermissionsExt;
-        self.mode() & 0o111 != 0
-    }
+#[cfg(target_os = "windows")]
+mod windows {
+    use std::os::windows::ffi::OsStrExt;
+    use std::path::Path;
 
-    #[cfg(not(unix))]
-    fn is_executable(&self) -> bool {
-        true
+    use winapi::ctypes::{c_ulong, wchar_t};
+    use winapi::um::winbase::GetBinaryTypeW;
+
+    use super::IsExecutable;
+
+    impl IsExecutable for Path {
+        fn is_executable(&self) -> bool {
+            let windows_string = self.encode_wide().chain(Some(0)).collect::<Vec<whcar_t>>();
+            let windows_string_ptr = windows_string.as_ptr();
+
+            let mut binary_type: c_ulong = 42;
+            let binary_type_ptr = &mut binary_type as *mut c_ulong;
+
+            let ret = unsafe { GetBinaryTypeW(windows_string_ptr, binary_type_ptr) };
+            if binary_type_ptr.is_null() {
+                return false;
+            }
+            if ret != 0 {
+                match unsafe { *binary_type_ptr } {
+                    0   // A 32-bit Windows-based application
+                    | 1 // An MS-DOS-based application
+                    | 2 // A 16-bit Windows-based application
+                    | 3 // A PIF file that executes an MS-DOS-based application
+                    | 4 // A POSIX – based application
+                    | 5 // A 16-bit OS/2-based application
+                    | 6 // A 64-bit Windows-based application
+                    => return true,
+                    _ => (),
+                }
+            }
+
+            false
+        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,6 +52,9 @@ The API comes in two flavors:
     ```
  */
 
+#[cfg(target_os = "windows")]
+extern crate winapi;
+
 use std::path::Path;
 
 /// Returns `true` if there is a file at the given path and it is
@@ -107,7 +110,11 @@ mod windows {
 
     impl IsExecutable for Path {
         fn is_executable(&self) -> bool {
-            let windows_string = self.encode_wide().chain(Some(0)).collect::<Vec<whcar_t>>();
+            let windows_string = self
+                .as_os_str()
+                .encode_wide()
+                .chain(Some(0))
+                .collect::<Vec<wchar_t>>();
             let windows_string_ptr = windows_string.as_ptr();
 
             let mut binary_type: c_ulong = 42;
@@ -118,7 +125,8 @@ mod windows {
                 return false;
             }
             if ret != 0 {
-                match unsafe { *binary_type_ptr } {
+                let binary_type = unsafe { *binary_type_ptr };
+                match binary_type {
                     0   // A 32-bit Windows-based application
                     | 1 // An MS-DOS-based application
                     | 2 // A 16-bit Windows-based application

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -2,13 +2,15 @@ extern crate diff;
 extern crate is_executable;
 
 use is_executable::is_executable;
-use std::env;
-use std::fs::File;
-use std::io::Read;
-use std::process::Command;
 
+#[cfg(unix)]
 #[test]
 fn cargo_readme_up_to_date() {
+    use std::env;
+    use std::fs::File;
+    use std::io::Read;
+    use std::process::Command;
+
     if env::var("CI").is_ok() {
         return;
     }
@@ -47,9 +49,16 @@ fn cargo_readme_up_to_date() {
     }
 }
 
+#[cfg(unix)]
 #[test]
 fn executable() {
     assert!(is_executable("./tests/i_am_executable"));
+}
+
+#[cfg(target_os = "windows")]
+#[test]
+fn executable() {
+    assert!(is_executable("C:\\Windows\\explorer.exe"));
 }
 
 #[test]

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -54,17 +54,10 @@ fn executable() {
 
 #[test]
 fn not_executable() {
-    assert_eq!(
-        is_executable("./tests/i_am_not_executable"),
-        if cfg!(unix) {
-            false
-        } else {
-            true
-        }
-    );
+    assert!(!is_executable("./tests/i_am_not_executable"));
 }
 
 #[test]
 fn non_existant() {
-    assert_eq!(false, is_executable("./tests/this-file-does-not-exist"));
+    assert!(!is_executable("./tests/this-file-does-not-exist"));
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -4,61 +4,69 @@ extern crate is_executable;
 use is_executable::is_executable;
 
 #[cfg(unix)]
-#[test]
-fn cargo_readme_up_to_date() {
+mod unix {
     use std::env;
     use std::fs::File;
     use std::io::Read;
     use std::process::Command;
 
-    if env::var("CI").is_ok() {
-        return;
-    }
+    use super::*;
 
-    println!("Checking that `cargo readme > README.md` is up to date...");
-
-    let expected = Command::new("cargo")
-        .arg("readme")
-        .current_dir(env!("CARGO_MANIFEST_DIR"))
-        .output()
-        .expect("should run `cargo readme` OK")
-        .stdout;
-    let expected = String::from_utf8_lossy(&expected);
-
-    let actual = {
-        let mut file = File::open(concat!(env!("CARGO_MANIFEST_DIR"), "/README.md"))
-            .expect("should open README.md file");
-        let mut s = String::new();
-        file.read_to_string(&mut s)
-            .expect("should read contents of file to string");
-        s
-    };
-
-    if actual != expected {
-        println!();
-        println!("+++ expected README.md");
-        println!("--- actual README.md");
-        for d in diff::lines(&expected, &actual) {
-            match d {
-                diff::Result::Left(l) => println!("+{}", l),
-                diff::Result::Right(r) => println!("-{}", r),
-                diff::Result::Both(b, _) => println!(" {}", b),
-            }
+    #[test]
+    fn cargo_readme_up_to_date() {
+        if env::var("CI").is_ok() {
+            return;
         }
-        panic!("Run `cargo readme > README.md` to update README.md")
-    }
-}
 
-#[cfg(unix)]
-#[test]
-fn executable() {
-    assert!(is_executable("./tests/i_am_executable"));
+        println!("Checking that `cargo readme > README.md` is up to date...");
+
+        let expected = Command::new("cargo")
+            .arg("readme")
+            .current_dir(env!("CARGO_MANIFEST_DIR"))
+            .output()
+            .expect("should run `cargo readme` OK")
+            .stdout;
+        let expected = String::from_utf8_lossy(&expected);
+
+        let actual = {
+            let mut file = File::open(concat!(env!("CARGO_MANIFEST_DIR"), "/README.md"))
+                .expect("should open README.md file");
+            let mut s = String::new();
+            file.read_to_string(&mut s)
+                .expect("should read contents of file to string");
+            s
+        };
+
+        if actual != expected {
+            println!();
+            println!("+++ expected README.md");
+            println!("--- actual README.md");
+            for d in diff::lines(&expected, &actual) {
+                match d {
+                    diff::Result::Left(l) => println!("+{}", l),
+                    diff::Result::Right(r) => println!("-{}", r),
+                    diff::Result::Both(b, _) => println!(" {}", b),
+                }
+            }
+            panic!("Run `cargo readme > README.md` to update README.md")
+        }
+    }
+
+    #[test]
+    fn executable() {
+        assert!(is_executable("./tests/i_am_executable"));
+    }
 }
 
 #[cfg(target_os = "windows")]
-#[test]
-fn executable() {
-    assert!(is_executable("C:\\Windows\\explorer.exe"));
+mod windows {
+    use super::*;
+
+    #[test]
+    fn executable() {
+        assert!(is_executable("C:\\Windows\\explorer.exe"));
+    }
+
 }
 
 #[test]


### PR DESCRIPTION
I had to solve this problem - identifying if a file is executable or not - in another crate I was working on and my solution needed to work with Windows. I discovered that one can use the [GetBinaryTypeW](https://docs.microsoft.com/en-us/windows/desktop/api/winbase/nf-winbase-getbinarytypew) function from the Windows API to accomplish this. Figured you might be interested in including this solution for Windows in your crate as well.