### PR TITLE
Try and determine executability using file extension on Windows

### DIFF
--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -82,6 +82,11 @@ mod windows {
         assert!(is_executable("C:\\Windows\\explorer.exe"));
     }
 
+    #[test]
+    fn by_extension() {
+        assert!(is_executable("./tests/i_am_executable_on_windows.bat"));
+    }
+
 }
 
 #[test]


### PR DESCRIPTION
Will close #5.

Adds additional logic using the example given in the above issue to check the file's extension to determine if it is executable, as this is the main way Windows does this. Should the file not have an extension (or the environment variable not be fetched successfully), the original method is used.

This fixes some files being falsely reported as not being executable, such as `.bat` files. A test has been added for this.

The only unpatched gap here is files with no extension that are scripts and such, like `.bat` files. Though at this point it becomes more of an issue with how Windows determines executability than the crate.

Given this changes the crate's behaviour, a version bump may be advisable if this is merged.

Let me know if any changes are needed!