### PR TITLE
Exclude AppVeyor config from the published crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ keywords = ["executable", "path", "file", "permissions"]
 license = "Apache-2.0/MIT"
 name = "is_executable"
 readme = "./README.md"
+exclude = ["/appveyor.yml"]
 repository = "https://github.com/fitzgen/is_executable"
 version = "1.0.1"
 


### PR DESCRIPTION
The AppVeyor config is only used for CI and isn't useful in the published crate, so exclude it from it.