### PR TITLE
Add file existence check before reading extension on Windows

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,7 +111,7 @@ mod windows {
     impl IsExecutable for Path {
         fn is_executable(&self) -> bool {
             // First, ensure that the file exists
-            if !self.is_file() {
+            if !self.exists() {
                 return false;
             }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,6 +110,11 @@ mod windows {
 
     impl IsExecutable for Path {
         fn is_executable(&self) -> bool {
+            // First, ensure that the file exists
+            if !self.is_file() {
+                return false;
+            }
+
             // Check using file extension
             if let Some(pathext) = std::env::var_os("PATHEXT") {
                 if let Some(extension) = self.extension() {

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -87,6 +87,11 @@ mod windows {
         assert!(is_executable("./tests/i_am_executable_on_windows.bat"));
     }
 
+    #[test]
+    fn non_existent_correct_extension() {
+        assert!(!is_executable("./tests/non_existent.exe"));
+    }
+
 }
 
 #[test]


### PR DESCRIPTION
Addresses fitzgen/is_executable#13.

On Windows, first ensure that the file exists before checking the extension in the filename.