### PR TITLE
Use windows-sys instead of winapi

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "is_executable"
-version = "1.0.4"
+version = "1.0.5"
 authors = ["Nick Fitzgerald <fitzgen@gmail.com>"]
 edition = "2021"
 description = "Is there an executable file at the given path?"
@@ -12,7 +12,7 @@ keywords = ["executable", "file", "path", "permissions"]
 categories = ["filesystem"]
 
 [target.'cfg(target_os = "windows")'.dependencies]
-winapi = { version = "0.3", features = ["winbase"] }
+windows-sys = { version = "0.60", features = ["Win32_Storage_FileSystem"] }
 
 [dev-dependencies]
 diff = "0.1.10"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 #![doc = include_str!("../README.md")]
 
 #[cfg(target_os = "windows")]
-extern crate winapi;
+extern crate windows_sys;
 
 use std::path::Path;
 
@@ -51,8 +51,7 @@ mod windows {
     use std::os::windows::ffi::OsStrExt;
     use std::path::Path;
 
-    use winapi::ctypes::{c_ulong, wchar_t};
-    use winapi::um::winbase::GetBinaryTypeW;
+    use windows_sys::Win32::Storage::FileSystem::GetBinaryTypeW;
 
     use super::IsExecutable;
 
@@ -89,11 +88,11 @@ mod windows {
                 .as_os_str()
                 .encode_wide()
                 .chain(Some(0))
-                .collect::<Vec<wchar_t>>();
+                .collect::<Vec<_>>();
             let windows_string_ptr = windows_string.as_ptr();
 
-            let mut binary_type: c_ulong = 42;
-            let binary_type_ptr = &mut binary_type as *mut c_ulong;
+            let mut binary_type: u32 = 42;
+            let binary_type_ptr = &mut binary_type as *mut u32;
 
             let ret = unsafe { GetBinaryTypeW(windows_string_ptr, binary_type_ptr) };
             if binary_type_ptr.is_null() {


### PR DESCRIPTION
`winapi` is now an unsupported crate, and the recommended way to interact with Windows APIs is to use `windows-sys`.