### PR TITLE
Allow `windows-sys` versions >=0.59, <=0.61

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["executable", "file", "path", "permissions"]
 categories = ["filesystem"]
 
 [target.'cfg(target_os = "windows")'.dependencies]
-windows-sys = { version = "0.60", features = ["Win32_Storage_FileSystem"] }
+windows-sys = { version = ">=0.59, <=0.61", features = ["Win32_Storage_FileSystem"] }
 
 [dev-dependencies]
 diff = "0.1.10"


### PR DESCRIPTION
This syntax is recommended by Microsoft in https://crates.io/crates/windows-sys/0.61.2.
It helps to eradicate duplicate `windows-sys` dependencies from the dependency tree of a complex project.

I'm particularly interested in `windows-sys` 0.61.x, because it consistently uses `raw-dylib` for importing APIs from Windows DLLs. This makes a huge difference when using non-MSVC toolchains to build Windows binaries, e.g. `x86_64-pc-windows-gnullvm`.

Tested with 0.59 and 0.61

CC @fitzgen 